### PR TITLE
feat: Compatibility for `{{ dbt_utils.get_relations_by_pattern() }}`

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,16 +16,6 @@ packages:
     version: 0.2.0
 ```
 
-For dbt >= v0.19.2, , add the following lines to your `dbt_project.yml`:
-
-```yaml
-dispatch:
-  - macro_namespace: dbt_utils
-    search_order: [athena_utils, dbt_utils]
-  - macro_namespace: dbt_expectations
-    search_order: [athena_utils, dbt_expectations]
-```
-
 For dbt < v0.19.2, add the following lines to your `dbt_project.yml`:
 
 ```yaml
@@ -33,13 +23,17 @@ vars:
   dbt_utils_dispatch_list: ["athena_utils"]
 ```
 
+For dbt >= v0.19.2, , add the following lines to your `dbt_project.yml`:
+
+```yaml
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order: [athena_utils, dbt_utils]
+```
 
 ## Compatibility
 
-This package provides compatibility "shims" for:
-- [dbt_utils](https://github.com/dbt-labs/dbt-utils) thanks to [@dbarok](https://github.com/dbarok) ([initial implementation](https://github.com/dbt-labs/dbt-utils/pull/380))
-- [dbt_expectations](https://github.com/calogica/dbt-expectations)
-
+This package provides "shims" for [`dbt_utils`](https://github.com/fishtown-analytics/dbt-utils) thanks to [@dbarok](https://github.com/dbarok) ([initial implementation](https://github.com/dbt-labs/dbt-utils/pull/380)).
 In the future more shims could be added to this repository.
 
 ### Contributing

--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ packages:
     version: 0.2.0
 ```
 
+For dbt >= v0.19.2, , add the following lines to your `dbt_project.yml`:
+
+```yaml
+dispatch:
+  - macro_namespace: dbt_utils
+    search_order: [athena_utils, dbt_utils]
+  - macro_namespace: dbt_expectations
+    search_order: [athena_utils, dbt_expectations]
+```
+
 For dbt < v0.19.2, add the following lines to your `dbt_project.yml`:
 
 ```yaml
@@ -23,17 +33,13 @@ vars:
   dbt_utils_dispatch_list: ["athena_utils"]
 ```
 
-For dbt >= v0.19.2, , add the following lines to your `dbt_project.yml`:
-
-```yaml
-dispatch:
-  - macro_namespace: dbt_utils
-    search_order: [athena_utils, dbt_utils]
-```
 
 ## Compatibility
 
-This package provides "shims" for [`dbt_utils`](https://github.com/fishtown-analytics/dbt-utils) thanks to [@dbarok](https://github.com/dbarok) ([initial implementation](https://github.com/dbt-labs/dbt-utils/pull/380)).
+This package provides compatibility "shims" for:
+- [dbt_utils](https://github.com/dbt-labs/dbt-utils) thanks to [@dbarok](https://github.com/dbarok) ([initial implementation](https://github.com/dbt-labs/dbt-utils/pull/380))
+- [dbt_expectations](https://github.com/calogica/dbt-expectations)
+
 In the future more shims could be added to this repository.
 
 ### Contributing

--- a/macros/dbt_utils/get_tables_by_pattern_sql.sql
+++ b/macros/dbt_utils/get_tables_by_pattern_sql.sql
@@ -1,0 +1,16 @@
+{% macro athena__get_tables_by_pattern_sql(schema_pattern, table_pattern, exclude='', database=target.database) %}
+
+    {% set sql %}
+        select
+            table_schema as "table_schema",
+            table_name as "table_name",
+            {{ dbt_utils.get_table_types_sql() }}
+        from {{ database }}.information_schema.tables
+        where table_schema like '{{ schema_pattern|lower }}'
+            and table_name like '{{ table_pattern|lower }}'
+            and table_name not like '{{ exclude|lower }}'
+    {% endset %}
+
+    {{ return(sql) }}
+
+{% endmacro %}


### PR DESCRIPTION
(PR originally open [here](https://github.com/dbt-athena/dbt-athena/pull/96), but moving to this repo after discussion)

This PR implements `dbt_utils.get_tables_by_pattern_sql()` for Athena.
This enables Athena users to use `dbt_utils.get_relations_by_pattern()` as well as various macros from the popular [codegen](https://hub.getdbt.com/dbt-labs/codegen/latest/) package.

Closes #5 