### PR TITLE
feat: Compatibility for `metrics.calculate` of `dbt_metrics`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ dispatch:
     search_order: [athena_utils, dbt_utils]
   - macro_namespace: dbt_expectations
     search_order: [athena_utils, dbt_expectations]
+  - macro_namespace: metrics
+    search_order: [athena_utils, metrics]
 ```
 
 For dbt < v0.19.2, add the following lines to your `dbt_project.yml`:
@@ -33,12 +35,13 @@ vars:
   dbt_utils_dispatch_list: ["athena_utils"]
 ```
 
-
 ## Compatibility
 
 This package provides compatibility "shims" for:
+
 - [dbt_utils](https://github.com/dbt-labs/dbt-utils) thanks to [@dbarok](https://github.com/dbarok) ([initial implementation](https://github.com/dbt-labs/dbt-utils/pull/380))
 - [dbt_expectations](https://github.com/calogica/dbt-expectations)
+- [dbt_metrics](https://github.com/dbt-labs/dbt_metrics/tree/1.3.2) (>=1.3.0, <1.4.0)
 
 In the future more shims could be added to this repository.
 

--- a/macros/dbt_metrics/gen_metric_cte.sql
+++ b/macros/dbt_metrics/gen_metric_cte.sql
@@ -1,0 +1,84 @@
+
+{%- macro athena__gen_metric_cte(metric_name, grain, dimensions, secondary_calculations, start_date, end_date, relevant_periods, calendar_dimensions, treat_null_values_as_zero) %}
+
+, {{metric_name}}__final as (
+
+    {%- if not treat_null_values_as_zero -%}
+        {%- set metric_val = metric_name -%}
+    {%- else -%}
+        {%- set metric_val = "coalesce(" ~ metric_name ~ ", 0) as " ~ metric_name -%}
+    {%- endif %}
+    
+    select
+        {% if grain != 'all_time' %}
+        date_{{grain}},
+            {%- if secondary_calculations | length > 0 -%}
+                {% for period in relevant_periods %}
+        parent_metric_cte.date_{{ period }},
+                {%- endfor -%}
+            {%- endif -%}
+        {%- endif -%}
+        
+        {%- for calendar_dim in calendar_dimensions %}
+        parent_metric_cte.{{ calendar_dim }},
+        {%- endfor %}
+
+        {%- for dim in dimensions %}
+        parent_metric_cte.{{ dim }},
+        {%- endfor %}
+        {{ metric_val }}
+        
+    {%- if grain == 'all_time' %}
+
+        ,metric_start_date
+        ,metric_end_date
+
+    from {{metric_name}}__aggregate as parent_metric_cte
+
+    {% else %}
+
+    from {{metric_name}}__spine_time as parent_metric_cte
+    left outer join {{metric_name}}__aggregate
+        using (
+            date_{{grain}}
+            {%- for calendar_dim in calendar_dimensions %}
+            , {{ calendar_dim }}
+            {%- endfor %}
+            {%- for dim in dimensions %}
+            , {{ dim }}
+            {%- endfor %}
+        )
+
+        {% if not start_date or not end_date -%}
+        where (
+            {% if not start_date and not end_date -%}
+            date_{{grain}} >= (
+                select 
+                    min(case when has_data then date_{{grain}} end) 
+                from {{metric_name}}__aggregate
+            )
+            and date_{{grain}} <= (
+                select 
+                    max(case when has_data then date_{{grain}} end) 
+                from {{metric_name}}__aggregate
+            )
+            {% elif not start_date and end_date -%}
+            date_{{grain}} >= (
+                select 
+                    min(case when has_data then date_{{grain}} end) 
+                from {{metric_name}}__aggregate
+            )
+            {% elif start_date and not end_date -%}
+            date_{{grain}} <= (
+                select 
+                    max(case when has_data then date_{{grain}} end) 
+                from {{metric_name}}__aggregate
+            )
+            {%- endif %} 
+        )      
+        {% endif %} 
+    {% endif -%}
+
+)
+
+{% endmacro %}

--- a/macros/dbt_metrics/gen_metric_cte.sql
+++ b/macros/dbt_metrics/gen_metric_cte.sql
@@ -20,11 +20,11 @@
         {%- endif -%}
         
         {%- for calendar_dim in calendar_dimensions %}
-        parent_metric_cte.{{ calendar_dim }},
+        {{ calendar_dim }},
         {%- endfor %}
 
         {%- for dim in dimensions %}
-        parent_metric_cte.{{ dim }},
+        {{ dim }},
         {%- endfor %}
         {{ metric_val }}
         


### PR DESCRIPTION
Implementation of the `metrics.gen_metric_cte` macro from the [dbt_metrics](https://hub.getdbt.com/dbt-labs/metrics/latest/) package.

This adds compatibility for calling the macro `dbt_metrics.calculate` using the dbt-athena adapter.

I initially created the issue in the dbt_metrics repo https://github.com/dbt-labs/dbt_metrics/issues/217 but @Jake-Gillberg pointed me out to this project, which I think is a better fit for this change.

One thing is that this macro will not work with the latest version of dbt_metrics (1.4.0) which was released last week. It is only compatible with versions `>=1.3.0, <1.4.0`. dbt_metrics 1.4.0 does not seem to be backwards compatible (Their documentation for version 1.4.0 says only it supports dbt versions: `>=1.4.0-a1, <1.5.0`
