### PR TITLE
Change dbt_utils.type_XXX to dbt.type_XXX

### DIFF
--- a/macros/dbt_date/calendar_date/convert_timezones.sql
+++ b/macros/dbt_date/calendar_date/convert_timezones.sql
@@ -1,3 +1,3 @@
 {%- macro athena__convert_timezone(column, target_tz, source_tz) -%}
-    CAST({{ column }} as {{ dbt_utils.type_timestamp() }}) AT TIME ZONE '{{ source_tz }}' AT TIME ZONE '{{ target_tz }}'
+    CAST({{ column }} as {{ dbt.type_timestamp() }}) AT TIME ZONE '{{ source_tz }}' AT TIME ZONE '{{ target_tz }}'
 {%- endmacro -%}

--- a/macros/dbt_utils/cross_db_utils/hash.sql
+++ b/macros/dbt_utils/cross_db_utils/hash.sql
@@ -1,8 +1,8 @@
 {%- macro hash(field) -%}
-  {{ return(adapter.dispatch('hash', 'dbt_utils') (field)) }}
+  {{ return(adapter.dispatch('hash', 'dbt') (field)) }}
 {%- endmacro -%}
 
 
 {%- macro athena__hash(field) -%}
-    to_hex(sha256(to_utf8(cast({{field}} as {{dbt_utils.type_string()}}))))
+    to_hex(sha256(to_utf8(cast({{field}} as {{dbt.type_string()}}))))
 {%- endmacro -%}


### PR DESCRIPTION
Fixes #10 
dbt_utils.type macros have been moved to dbt.type macros for the 1.0.0 dbt_utils upgrade