### PR TITLE
fix: test_not_null_proportion support on athena

### DIFF
--- a/macros/dbt_utils/generic_tests/not_null_proportion.sql
+++ b/macros/dbt_utils/generic_tests/not_null_proportion.sql
@@ -1,0 +1,30 @@
+{% macro athena__test_not_null_proportion(model, group_by_columns) %}
+
+{% set column_name = kwargs.get('column_name', kwargs.get('arg')) %}
+{% set at_least = kwargs.get('at_least', kwargs.get('arg')) %}
+{% set at_most = kwargs.get('at_most', kwargs.get('arg', 1)) %}
+
+{% if group_by_columns|length() > 0 %}
+  {% set select_gb_cols = group_by_columns|join(' ,') + ', ' %}
+  {% set groupby_gb_cols = 'group by ' + group_by_columns|join(',') %}
+{% endif %}
+
+with validation as (
+  select
+    {{select_gb_cols}}
+    sum(case when {{ column_name }} is null then 0 else 1 end) / cast(count(*) as double) as not_null_proportion
+  from {{ model }}
+  {{groupby_gb_cols}}
+),
+validation_errors as (
+  select
+    {{select_gb_cols}}
+    not_null_proportion
+  from validation
+  where not_null_proportion < {{ at_least }} or not_null_proportion > {{ at_most }}
+)
+select
+  *
+from validation_errors
+
+{% endmacro %}


### PR DESCRIPTION
### Problem
The issue is that for this test dbt_utils uses a `cast(... as numeric)` which does not exist in athena (https://github.com/dbt-labs/dbt-utils/blob/main/macros/generic_tests/not_null_proportion.sql#L19)

### Solution
I created the same macro but use a cast a double to work with Athena