### PR TITLE
fix: Link to new DBT dispatch docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This [dbt](https://github.com/fishtown-analytics/dbt) package contains macros
 that:
 
 - can be (re)used across dbt projects running on Athena
-- define Athena-specific implementations of [dispatched macros](https://docs.getdbt.com/reference/dbt-jinja-functions/adapter/#dispatch) from other packages
+- define Athena-specific implementations of [dispatched macros](https://docs.getdbt.com/reference/dbt-jinja-functions/dispatch) from other packages
 
 ## Installation Instructions
 


### PR DESCRIPTION
Update link as docs moved to separate page:
![image](https://github.com/user-attachments/assets/392b5474-a5c3-4be2-a446-db480f8b81a4)
